### PR TITLE
fix: no-warning-comments is case insensitive

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -442,7 +442,7 @@ module.exports = {
 			1,
 			{
 				location: "start",
-				terms: ["TODO", "todo", "@toto"],
+				terms: ["todo", "@toto"],
 			},
 		],
 		"no-whitespace-before-property": 2,

--- a/src/common.js
+++ b/src/common.js
@@ -442,7 +442,7 @@ module.exports = {
 			1,
 			{
 				location: "start",
-				terms: ["todo", "@toto"],
+				terms: ["todo", "@todo"],
 			},
 		],
 		"no-whitespace-before-property": 2,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As per https://eslint.org/docs/latest/rules/no-warning-comments, the `no-warning-comments` terms are case insensitive. The current config is generating duplicate warnings for each comment.

Additionally, I am unsure if `@toto` is a typo of `@todo` and have left it alone, but I wanted to bring attention to it in case it *is* a typo.