### PR TITLE
chore: remove double root from readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ This package includes the following configurations:
 ```json
 {
 	"root": true,
-	"root": true,
 	"extends": ["neon/common", "neon/node", "neon/typescript", "neon/prettier"],
 	"parserOptions": {
 		"project": "./tsconfig.json"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Duplicate key in one readme example