### PR TITLE
chore: Update react/jsx-sort-default-props to react/sort-default-props

### DIFF
--- a/src/jsx.js
+++ b/src/jsx.js
@@ -104,7 +104,6 @@ module.exports = {
 		],
 		"react/jsx-props-no-multi-spaces": 2,
 		"react/jsx-props-no-spreading": 0,
-		"react/jsx-sort-default-props": 2,
 		"react/jsx-sort-props": 2,
 		"react/jsx-tag-spacing": [
 			2,

--- a/src/react.js
+++ b/src/react.js
@@ -63,6 +63,7 @@ module.exports = {
 		"react/require-optimization": 0,
 		"react/require-render-return": 2,
 		"react/self-closing-comp": 2,
+		"react/sort-default-props": 2,
 		"react/sort-comp": 2,
 		"react/sort-prop-types": 2,
 		"react/state-in-constructor": [2, "always"],


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- https://github.com/jsx-eslint/eslint-plugin-react/pull/1861