### PR TITLE
refactor: split sonar to its own config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This package includes the following configurations:
 - [`eslint-config-neon/react`](./src/react.ts) – for usage with [React](https://reactjs.org/).
 - [`eslint-config-neon/rxjs`](./src/rxjs.ts) – for usage with [RxJS](https://rxjs.dev/).
 - [`eslint-config-neon/rxjs-angular`](./src/rxjs-angular.ts) – for usage [RxJS](https://rxjs.dev/) and [Angular](https://angular.io/).
+- [`eslint-config-neon/sonar`](./src/sonar.ts) – ESLint rules that match [The Sonar Way](https://rules.sonarsource.com/javascript).
 - [`eslint-config-neon/svelte`](./src/svelte.ts) – for usage with [Svelte](https://svelte.dev/).
 - [`eslint-config-neon/svelte-typescript`](./src/svelte-typescript.ts) – for usage with [Svelte](https://svelte.dev/) and [TypeScript](http://typescriptlang.org/).
 - [`eslint-config-neon/typescript`](./src/typescript.ts) – for usage with [TypeScript](http://typescriptlang.org/).

--- a/package.json
+++ b/package.json
@@ -197,6 +197,16 @@
 				"default": "./dist/cjs/rxjs.cjs"
 			}
 		},
+		"./sonar": {
+			"import": {
+				"types": "./dist/esm/sonar.d.mts",
+				"default": "./dist/esm/sonar.mjs"
+			},
+			"require": {
+				"types": "./dist/cjs/sonar.d.cts",
+				"default": "./dist/cjs/sonar.cjs"
+			}
+		},
 		"./svelte-typescript": {
 			"import": {
 				"types": "./dist/esm/svelte-typescript.d.mts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export { default as prettier } from "./prettier";
 export { default as react } from "./react";
 export { default as rxjs } from "./rxjs";
 export { default as rxjsangular } from "./rxjs-angular";
+export { default as sonar } from "./sonar";
 export { default as svelte } from "./svelte";
 export { default as sveltetypescript } from "./svelte-typescript";
 export { default as typescript } from "./typescript";

--- a/src/sonar.ts
+++ b/src/sonar.ts
@@ -1,0 +1,47 @@
+import type { TSESLint } from "@typescript-eslint/utils";
+import eslintPluginSonarjs from "eslint-plugin-sonarjs";
+
+const rules: TSESLint.FlatConfig.Rules = {
+	"sonarjs/no-all-duplicated-branches": 2,
+	"sonarjs/no-element-overwrite": 2,
+	"sonarjs/no-empty-collection": 2,
+	"sonarjs/no-extra-arguments": 2,
+	"sonarjs/no-identical-conditions": 2,
+	"sonarjs/no-identical-expressions": 2,
+	"sonarjs/no-ignored-return": 2,
+	"sonarjs/no-one-iteration-loop": 2,
+	"sonarjs/no-use-of-empty-return-value": 2,
+	"sonarjs/non-existent-operator": 2,
+	"sonarjs/elseif-without-else": 0,
+	"sonarjs/max-switch-cases": 0,
+	"sonarjs/no-collapsible-if": 2,
+	"sonarjs/no-collection-size-mischeck": 2,
+	"sonarjs/no-duplicate-string": 0,
+	"sonarjs/no-duplicated-branches": 2,
+	"sonarjs/no-gratuitous-expressions": 2,
+	"sonarjs/no-identical-functions": 2,
+	"sonarjs/no-inverted-boolean-check": 2,
+	"sonarjs/no-nested-switch": 2,
+	"sonarjs/no-nested-template-literals": 0,
+	"sonarjs/no-redundant-boolean": 2,
+	"sonarjs/no-redundant-jump": 2,
+	"sonarjs/no-same-line-conditional": 2,
+	"sonarjs/no-small-switch": 0,
+	"sonarjs/no-unused-collection": 2,
+	"sonarjs/no-useless-catch": 0,
+	"sonarjs/prefer-immediate-return": 2,
+	"sonarjs/prefer-object-literal": 2,
+	"sonarjs/prefer-single-boolean-return": 2,
+	"sonarjs/prefer-while": 2,
+};
+
+const config: TSESLint.FlatConfig.ConfigArray = [
+	{
+		plugins: {
+			sonarjs: eslintPluginSonarjs,
+		},
+		rules,
+	},
+];
+
+export default config;

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -1,6 +1,5 @@
 import { fixupPluginRules } from "@eslint/compat";
 import type { TSESLint } from "@typescript-eslint/utils";
-import eslintPluginSonarjs from "eslint-plugin-sonarjs";
 import eslintPluginTsdoc from "eslint-plugin-tsdoc";
 // @ts-expect-error eslint-plugin-typescript-sort-keys is not typed
 import eslintPluginTypescriptSortKeys from "eslint-plugin-typescript-sort-keys";
@@ -334,37 +333,6 @@ const rules: TSESLint.FlatConfig.Rules = {
 	"jsdoc/require-property-type": 0,
 	"no-undef": 0,
 	"n/global-require": 0,
-	"sonarjs/no-all-duplicated-branches": 2,
-	"sonarjs/no-element-overwrite": 2,
-	"sonarjs/no-empty-collection": 2,
-	"sonarjs/no-extra-arguments": 2,
-	"sonarjs/no-identical-conditions": 2,
-	"sonarjs/no-identical-expressions": 2,
-	"sonarjs/no-ignored-return": 2,
-	"sonarjs/no-one-iteration-loop": 2,
-	"sonarjs/no-use-of-empty-return-value": 2,
-	"sonarjs/non-existent-operator": 2,
-	"sonarjs/elseif-without-else": 0,
-	"sonarjs/max-switch-cases": 0,
-	"sonarjs/no-collapsible-if": 2,
-	"sonarjs/no-collection-size-mischeck": 2,
-	"sonarjs/no-duplicate-string": 0,
-	"sonarjs/no-duplicated-branches": 2,
-	"sonarjs/no-gratuitous-expressions": 2,
-	"sonarjs/no-identical-functions": 2,
-	"sonarjs/no-inverted-boolean-check": 2,
-	"sonarjs/no-nested-switch": 2,
-	"sonarjs/no-nested-template-literals": 0,
-	"sonarjs/no-redundant-boolean": 2,
-	"sonarjs/no-redundant-jump": 2,
-	"sonarjs/no-same-line-conditional": 2,
-	"sonarjs/no-small-switch": 0,
-	"sonarjs/no-unused-collection": 2,
-	"sonarjs/no-useless-catch": 0,
-	"sonarjs/prefer-immediate-return": 2,
-	"sonarjs/prefer-object-literal": 2,
-	"sonarjs/prefer-single-boolean-return": 2,
-	"sonarjs/prefer-while": 2,
 	"tsdoc/syntax": 1,
 	"typescript-sort-keys/interface": 2,
 	"typescript-sort-keys/string-enum": 2,
@@ -392,7 +360,6 @@ const settings: TSESLint.FlatConfig.Settings = {
 
 const config: TSESLint.FlatConfig.ConfigArray = tseslint.config(...tseslint.configs.recommended, {
 	plugins: {
-		sonarjs: eslintPluginSonarjs,
 		tsdoc: eslintPluginTsdoc,
 		"typescript-sort-keys": fixupPluginRules(eslintPluginTypescriptSortKeys),
 	},


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

TL;DR: I want to be able to not load the sonarjs plugin

Sonarlint plugin is giving lots of trouble because the versions of their dependencies is behind neon, in particular typescript-eslint being v7 with sonar. This is giving lots of conflicting dependencies issues. I'm also getting issues relating to Sonar forcing a dependency of for example eslint-plugin-react despite the project not needing or configuring React. Even if I allow Yarn to pull in all dependencies and not skip anything I still get this error now:
```
Oops! Something went wrong! :(

ESLint: 9.15.0

TypeError: Cannot read properties of undefined (reading 'meta')
    at decorate (/Users/favna/workspace/favware/discord-application-emojis-manager/node_modules/eslint-plugin-sonarjs/cjs/S1116/decorator.js:12:65)
    at Object.<anonymous> (/Users/favna/workspace/favware/discord-application-emojis-manager/node_modules/eslint-plugin-sonarjs/cjs/S1116/index.js:25:44)
    at Module._compile (node:internal/modules/cjs/loader:1546:14)
    at Object..js (node:internal/modules/cjs/loader:1689:10)
    at Module.load (node:internal/modules/cjs/loader:1318:32)
    at Function._load (node:internal/modules/cjs/loader:1128:12)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:218:24)
    at Module.require (node:internal/modules/cjs/loader:1340:12)
    at require (node:internal/modules/helpers:141:16)
```