### PR TITLE
fix(typescript): allow boolean primitives for `prefer-nullish-coalescing`

### DIFF
--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -159,6 +159,12 @@ const rules: TSESLint.FlatConfig.Rules = {
 		{
 			ignoreConditionalTests: true,
 			ignoreMixedLogicalExpressions: true,
+			ignorePrimitives: {
+				bigint: false,
+				boolean: true,
+				number: false,
+				string: false,
+			},
 		},
 	],
 	"@typescript-eslint/prefer-optional-chain": 2,


### PR DESCRIPTION
This seems to have been a change to typescript eslint and without this change (which might I add is _not_ the default) it trips even on code such as 

```ts
Array.filter((row) => row.booleanValueOne || row.booleanValueTwo)
```
which it really should not as this is perfectly valid and using nullish coalescing here is distinctly different from an or operator.