### PR TITLE
Add homepage metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"bugs": {
 		"url": "https://github.com/iCrawl/eslint-config-neon/issues"
 	},
+	"homepage": "https://github.com/iCrawl/eslint-config-neon#readme",
 	"license": "Apache-2.0",
 	"author": "iCrawl <icrawltogo@gmail.com>",
 	"repository": {


### PR DESCRIPTION
## Summary

Adds the package homepage metadata to `package.json`, pointing to this repository's README.

This leaves runtime code, dependencies, generated files, package exports, and version fields unchanged.

## Validation

- `node -e "const p=require('./package.json'); if (p.homepage !== 'https://github.com/iCrawl/eslint-config-neon#readme') throw new Error('homepage missing or incorrect'); console.log(JSON.stringify({name:p.name,version:p.version,homepage:p.homepage}))"`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`