### PR TITLE
docs: add missing homepage metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"typescript",
 		"validate"
 	],
+	"homepage": "https://github.com/iCrawl/eslint-config-neon#readme",
 	"bugs": {
 		"url": "https://github.com/iCrawl/eslint-config-neon/issues"
 	},


### PR DESCRIPTION
This PR adds the missing homepage field to package.json.

CC: @iCrawl